### PR TITLE
Refactor email sender to use IEmailSender interface

### DIFF
--- a/src/Cursus.MVC/Areas/Identity/Pages/Account/ForgotPassword.cshtml.cs
+++ b/src/Cursus.MVC/Areas/Identity/Pages/Account/ForgotPassword.cshtml.cs
@@ -5,6 +5,7 @@
 using Cursus.Domain.Models;
 using Cursus.MVC.Services;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.UI.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.WebUtilities;
@@ -17,9 +18,9 @@ namespace Cursus.MVC.Areas.Identity.Pages.Account
     public class ForgotPasswordModel : PageModel
     {
         private readonly UserManager<ApplicationUser> _userManager;
-        private readonly EmailSender _emailSender;
+        private readonly IEmailSender _emailSender;
 
-        public ForgotPasswordModel(UserManager<ApplicationUser> userManager, EmailSender emailSender)
+        public ForgotPasswordModel(UserManager<ApplicationUser> userManager, IEmailSender emailSender)
         {
             _userManager = userManager;
             _emailSender = emailSender;
@@ -68,10 +69,11 @@ namespace Cursus.MVC.Areas.Identity.Pages.Account
                     values: new { area = "Identity", code },
                     protocol: Request.Scheme);
 
+                var emailSender = (EmailSender)_emailSender;
                 await _emailSender.SendEmailAsync(
                     Input.Email,
                     "Reset Password",
-                    _emailSender.EmailConfirm(user.UserName, $"<h3>To reset your password, please click the link below: </h3><div style='text-align: center;'><a style='color: white;' class='link-confirm' href='{HtmlEncoder.Default.Encode(callbackUrl)}'>Reset Password</a></div>"));
+                    emailSender.EmailConfirm(user.UserName, $"<h3>To reset your password, please click the link below: </h3><div style='text-align: center;'><a style='color: white;' class='link-confirm' href='{HtmlEncoder.Default.Encode(callbackUrl)}'>Reset Password</a></div>"));
 
                 return RedirectToPage("./ForgotPasswordConfirmation");
             }

--- a/src/Cursus.MVC/Areas/Identity/Pages/Account/Manage/ChangePassword.cshtml.cs
+++ b/src/Cursus.MVC/Areas/Identity/Pages/Account/Manage/ChangePassword.cshtml.cs
@@ -21,14 +21,14 @@ namespace Cursus.MVC.Areas.Identity.Pages.Account.Manage
         private readonly SignInManager<ApplicationUser> _signInManager;
         private readonly ILogger<ChangePasswordModel> _logger;
         private readonly Cursus.Domain.Models.CursusDBContext _db;
-        private readonly EmailSender _emailSender;
+        private readonly IEmailSender _emailSender;
 
         public ChangePasswordModel(
             UserManager<ApplicationUser> userManager,
             SignInManager<ApplicationUser> signInManager,
             ILogger<ChangePasswordModel> logger,
             CursusDBContext db,
-            EmailSender emailSender)
+            IEmailSender emailSender)
         {
             _userManager = userManager;
             _signInManager = signInManager;
@@ -125,7 +125,8 @@ namespace Cursus.MVC.Areas.Identity.Pages.Account.Manage
                 {
                     account.Password = Input.NewPassword;
                     _db.Accounts.Update(account);
-                    var htmlContent = _emailSender.EmailChangePassword(account.FullName);
+                    var emailSender = (EmailSender)_emailSender;
+                    var htmlContent = emailSender.EmailChangePassword(account.FullName);
                     await _emailSender.SendEmailAsync(account.Email, "Change Password", htmlContent);
                     await _db.SaveChangesAsync();
                 }

--- a/src/Cursus.MVC/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/src/Cursus.MVC/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -33,7 +33,7 @@ namespace Cursus.MVC.Areas.Identity.Pages.Account
 		private readonly IUserStore<ApplicationUser> _userStore;
 		private readonly IUserEmailStore<ApplicationUser> _emailStore;
 		private readonly ILogger<RegisterModel> _logger;
-		private readonly EmailSender _emailSender;
+		private readonly IEmailSender _emailSender;
 		private readonly Cursus.Domain.Models.CursusDBContext _db;
 		private readonly RoleManager<IdentityRole> _roleManager;
 
@@ -42,7 +42,7 @@ namespace Cursus.MVC.Areas.Identity.Pages.Account
             IUserStore<ApplicationUser> userStore,
             SignInManager<ApplicationUser> signInManager,
             ILogger<RegisterModel> logger,
-            EmailSender emailSender,
+            IEmailSender emailSender,
             CursusDBContext db,
             RoleManager<IdentityRole> roleManager)
         {
@@ -148,7 +148,8 @@ namespace Cursus.MVC.Areas.Identity.Pages.Account
 						values: new { area = "Identity", userId = userId, code = code, returnUrl = returnUrl },
 						protocol: Request.Scheme);
 
-					var htmlContent = _emailSender.EmailConfirm(user.UserName, $"<h3>To confirm your email address to register, please click the link below: </h3><div style='text-align: center;'><a style='color: white;' class='link-confirm' href='{HtmlEncoder.Default.Encode(callbackUrl)}'>Confirm Email</a></div>");
+					var emailSender = (EmailSender)_emailSender;
+					var htmlContent = emailSender.EmailConfirm(user.UserName, $"<h3>To confirm your email address to register, please click the link below: </h3><div style='text-align: center;'><a style='color: white;' class='link-confirm' href='{HtmlEncoder.Default.Encode(callbackUrl)}'>Confirm Email</a></div>");
 					await _emailSender.SendEmailAsync(
 						Input.Email, 
 						"Confirm your email",

--- a/src/Cursus.MVC/Controllers/PayoutController.cs
+++ b/src/Cursus.MVC/Controllers/PayoutController.cs
@@ -33,7 +33,7 @@ namespace Cursus.MVC.Controllers
         {
             ClaimsPrincipal claims = this.User;
             var userID = claims.FindFirst(ClaimTypes.NameIdentifier)?.Value;
-            
+
             if (string.IsNullOrEmpty(userID))
             {
                 TempData["Status"] = "InvalidUser";
@@ -88,7 +88,7 @@ namespace Cursus.MVC.Controllers
 
             ClaimsPrincipal claims = this.User;
             var userID = claims.FindFirst(ClaimTypes.NameIdentifier)?.Value;
-            
+
             if (string.IsNullOrEmpty(userID))
             {
                 TempData["Status"] = "InvalidUser";
@@ -96,7 +96,7 @@ namespace Cursus.MVC.Controllers
             }
             // Update account money first
             var updatedAccount = _payoutService.UpdateAccMoney(userID, total);
-            
+
             if (updatedAccount == null)
             {
                 TempData["Status"] = "WithdrawnFail";
@@ -117,27 +117,27 @@ namespace Cursus.MVC.Controllers
                 TempData["Status"] = "WithdrawnFail";
                 return RedirectToAction("Error404", "Home");
             }
-            
+
             // Send confirmation email
             var emailSender = (EmailSender)_emailSender;
             var htmlContent = emailSender.PayOutConfirm(account.FullName, total);
             await _emailSender.SendEmailAsync(account.Email, "Confirm Payment", htmlContent);
-            
+
             TempData["Status"] = "WithdrawnSuccess";
             TempData["WithdrawnAmount"] = total;
             return RedirectToAction("Success", "Payout");
         }
-        
+
         [Authorize(Roles = "Instructor")]
         public IActionResult Success()
         {
             // Pass the success message and withdrawn amount to the view
             ViewBag.SuccessMessage = TempData["Status"];
             ViewBag.WithdrawnAmount = TempData["WithdrawnAmount"];
-            
+
             // Set a flag to redirect after 3 seconds
             ViewBag.RedirectToIndex = true;
-            
+
             return View();
         }
     }

--- a/src/Cursus.MVC/Program.cs
+++ b/src/Cursus.MVC/Program.cs
@@ -255,11 +255,9 @@ namespace Cursus.MVC
                     cursusDbContext.Database.Migrate();
 
                     // Seed data if in development environment
-                    if (app.Environment.IsDevelopment())
-                    {
-                        var seeder = services.GetRequiredService<DatabaseSeeder>();
-                        await seeder.SeedAsync();
-                    }
+                    var seeder = services.GetRequiredService<DatabaseSeeder>();
+                    await seeder.SeedAsync();
+
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
Replaced direct usage of EmailSender with the IEmailSender interface in account and payout-related controllers and pages. Updated constructor dependencies and casting where EmailSender-specific methods are needed. Also, removed development environment check for database seeding in Program.cs to always seed the database.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized email sending through an interface for account-related actions (no user-facing changes).
* **Chores**
  * Ensures initial data is seeded after startup in all environments for a consistent setup experience.
* **Style**
  * Minor whitespace cleanup with no functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->